### PR TITLE
Fix #18. Removed alphanumeric validation enforcement on STK Push

### DIFF
--- a/src/Mpesa/C2B/STK.php
+++ b/src/Mpesa/C2B/STK.php
@@ -74,7 +74,6 @@ class STK
      */
     public function usingReference($reference, $description)
     {
-
         $this->reference   = $reference;
         $this->description = $description;
 

--- a/src/Mpesa/C2B/STK.php
+++ b/src/Mpesa/C2B/STK.php
@@ -74,11 +74,6 @@ class STK
      */
     public function usingReference($reference, $description)
     {
-//        \preg_match('/[^A-Za-z0-9]/', $reference, $matches);
-//
-//        if (\count($matches)) {
-//            throw new \InvalidArgumentException('Reference should be alphanumeric.');
-//        }
 
         $this->reference   = $reference;
         $this->description = $description;

--- a/src/Mpesa/C2B/STK.php
+++ b/src/Mpesa/C2B/STK.php
@@ -74,11 +74,11 @@ class STK
      */
     public function usingReference($reference, $description)
     {
-        \preg_match('/[^A-Za-z0-9]/', $reference, $matches);
-
-        if (\count($matches)) {
-            throw new \InvalidArgumentException('Reference should be alphanumeric.');
-        }
+//        \preg_match('/[^A-Za-z0-9]/', $reference, $matches);
+//
+//        if (\count($matches)) {
+//            throw new \InvalidArgumentException('Reference should be alphanumeric.');
+//        }
 
         $this->reference   = $reference;
         $this->description = $description;


### PR DESCRIPTION
To allow accounts with hypens, underscores and fullstops as per the issue #18 