### PR TITLE
Add support for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require": {
         "php": ">=5.6.0",
         "guzzlehttp/guzzle": "^6.2",
-        "illuminate/support": "^5.0",
+        "illuminate/support": "^5.0|^6.0",
         "nesbot/carbon": "^1.0 || ^2.0",
         "predis/predis": "^1.1"
     },

--- a/src/Mpesa/C2B/Identity.php
+++ b/src/Mpesa/C2B/Identity.php
@@ -4,6 +4,7 @@ namespace SmoDav\Mpesa\C2B;
 
 use Carbon\Carbon;
 use GuzzleHttp\Exception\RequestException;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use SmoDav\Mpesa\Engine\Core;
 use SmoDav\Mpesa\Repositories\ConfigurationRepository;
@@ -32,7 +33,7 @@ class Identity
      */
     public function validate($number, $callback = null, $account = null)
     {
-        if (! starts_with($number, '2547')) {
+        if (! Str::startsWith($number, '2547')) {
             throw new InvalidArgumentException('The subscriber number must start with 2547');
         }
 

--- a/src/Mpesa/C2B/STK.php
+++ b/src/Mpesa/C2B/STK.php
@@ -4,6 +4,7 @@ namespace SmoDav\Mpesa\C2B;
 
 use Carbon\Carbon;
 use GuzzleHttp\Exception\RequestException;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use SmoDav\Mpesa\Engine\Core;
 use SmoDav\Mpesa\Repositories\ConfigurationRepository;
@@ -112,7 +113,7 @@ class STK
      */
     public function from($number)
     {
-        if (! starts_with($number, '2547')) {
+        if (! Str::startsWith($number, '2547')) {
             throw new InvalidArgumentException('The subscriber number must start with 2547');
         }
 

--- a/src/Mpesa/C2B/Simulate.php
+++ b/src/Mpesa/C2B/Simulate.php
@@ -3,6 +3,7 @@
 namespace SmoDav\Mpesa\C2B;
 
 use GuzzleHttp\Exception\RequestException;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use SmoDav\Mpesa\Engine\Core;
 use SmoDav\Mpesa\Exceptions\ErrorException;
@@ -91,7 +92,7 @@ class Simulate
      */
     public function from($number)
     {
-        if (! starts_with($number, '2547')) {
+        if (! Str::startsWith($number, '2547')) {
             throw new \InvalidArgumentException('The subscriber number must start with 2547');
         }
 


### PR DESCRIPTION
- Updated dependencies
- Changed helper `starts_with` according to upgrade guide [https://laravel.com/docs/6.0/upgrade#helpers](https://laravel.com/docs/6.0/upgrade#helpers)