### PR TITLE
Cast string to int before calling addSeconds

### DIFF
--- a/src/Mpesa/Auth/Authenticator.php
+++ b/src/Mpesa/Auth/Authenticator.php
@@ -116,7 +116,8 @@ class Authenticator
      */
     private function saveCredentials($key, $credentials)
     {
-        $ttl = Carbon::now()->addSeconds($credentials->expires_in)->subMinute();
+        $ttlSeconds = (int) $credentials->expires_in;
+        $ttl = Carbon::now()->addSeconds($ttlSeconds)->subMinute();
 
         $this->core->cache()->put($key, $credentials->access_token, $ttl);
     }


### PR DESCRIPTION
Got an error in Carbon while testing this package in laravel.
Submitting a fix for it and hopping that I'm not violating any of your contribution guidelines if you have any. 

![Screenshot from 2026-03-14 23-52-43-EDIT](https://github.com/user-attachments/assets/de94a646-0504-4ac4-a8c9-77a1fca8b581)

Mpesa auth response is a string while Carbon expects an int or float when adding seconds. 
I fixed it by casting to int before calling addSeconds.